### PR TITLE
Publish library to bintray repository

### DIFF
--- a/LongPressListener/build.gradle
+++ b/LongPressListener/build.gradle
@@ -4,11 +4,11 @@ apply plugin: 'kotlin-android-extensions'
 apply from: 'publish.gradle'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode 1
         versionName this.version
 

--- a/LongPressListener/build.gradle
+++ b/LongPressListener/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
+apply from: 'publish.gradle'
 
 android {
     compileSdkVersion 29
@@ -9,7 +10,7 @@ android {
         minSdkVersion 21
         targetSdkVersion 29
         versionCode 1
-        versionName "1.0"
+        versionName this.version
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/LongPressListener/publish.gradle
+++ b/LongPressListener/publish.gradle
@@ -1,0 +1,35 @@
+apply plugin: 'com.jfrog.bintray'
+apply plugin: 'com.github.dcendents.android-maven'
+
+group 'com.spoqa.longpresslistener'
+version '1.0.0'
+
+ext {
+    bintrayRepo = 'maven'
+    bintrayName = 'LongPressListener'
+    organization = 'spoqa'
+
+    // Library Details
+    publishedGroupId = this.group
+    libraryName = 'LongPressListener'
+    artifact = 'LongPressListener'
+    libraryDescription = 'Android long press(click) listener with custom duration'
+    libraryVersion = this.version
+
+    // Repository Link (For e.g. GitHub repo)
+    siteUrl = 'https://github.com/spoqa/LongPressListener'
+    gitUrl = 'https://github.com/spoqa/LongPressListener.git'
+    issueTrackerUrl = 'https://github.com/spoqa/LongPressListener/issues'
+    // Set githubRepository after project is public
+    // githubRepository= 'spoqa/LongPressListener'
+
+    // Developer details
+    developerId = 'wisemuji'
+    developerName = 'Suhyeon Kim'
+    developerEmail = 'dev@spoqa.com'
+
+    // License information
+    licenseName = 'The MIT License (MIT)'
+    licenseUrl = 'https://opensource.org/licenses/MIT'
+    allLicenses = ["MIT"]
+}

--- a/LongPressListener/publish.gradle
+++ b/LongPressListener/publish.gradle
@@ -33,3 +33,88 @@ ext {
     licenseUrl = 'https://opensource.org/licenses/MIT'
     allLicenses = ["MIT"]
 }
+
+group = publishedGroupId
+
+install {
+    repositories.mavenInstaller {
+        // This generates POM.xml with proper parameters
+        pom {
+            project {
+                packaging 'aar'
+
+                groupId publishedGroupId
+                artifactId = artifact
+                name libraryName
+                description = libraryDescription
+                url siteUrl
+
+                licenses {
+                    license {
+                        name licenseName
+                        url licenseUrl
+                    }
+                }
+                developers {
+                    developer {
+                        id developerId
+                        name developerName
+                        email developerEmail
+                    }
+                }
+                scm {
+                    connection gitUrl
+                    developerConnection gitUrl
+                    url siteUrl
+                }
+            }
+        }
+    }
+}
+
+// Avoid Kotlin docs error
+tasks.withType(Javadoc) {
+    enabled = false
+}
+
+// Remove javadoc related tasks
+task javadoc(type: Javadoc) {
+    // If using .kt files
+    excludes = ['**/*.kt']
+    source = android.sourceSets.main.java.srcDirs
+    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+}
+
+task sourcesJar(type: Jar) {
+    from android.sourceSets.main.java.srcDirs
+    classifier = 'sources'
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier = 'javadoc'
+    from javadoc.destinationDir
+}
+artifacts {
+    archives javadocJar
+    archives sourcesJar
+}
+
+// https://github.com/bintray/gradle-bintray-plugin
+bintray {
+    user = System.getenv("BINTRAY_USER")
+    key = System.getenv("BINTRAY_API_KEY")
+
+    configurations = ['archives']
+    pkg {
+        repo = bintrayRepo
+        name = bintrayName
+        websiteUrl = siteUrl
+        vcsUrl = gitUrl
+        issueTrackerUrl = issueTrackerUrl
+        // Set githubRepository after project is public
+        // githubRepo = githubRepository
+        licenses = allLicenses
+        userOrg = organization
+        publish = true
+    }
+}

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,12 +3,12 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
 
     defaultConfig {
         applicationId "com.spoqa.longpresslistener"
         minSdkVersion 21
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:4.0.0"
+        classpath "com.android.tools.build:gradle:4.0.1"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,6 @@
-// Top-level build file where you can add configuration options common to all sub-projects/modules.
+apply plugin: 'com.jfrog.bintray'
+apply plugin: 'maven-publish'
+
 buildscript {
     ext.kotlin_version = "1.3.72"
     repositories {
@@ -8,9 +10,10 @@ buildscript {
     dependencies {
         classpath "com.android.tools.build:gradle:4.0.1"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
+        // Do not update before
+        // https://github.com/bintray/gradle-bintray-plugin/issues/267 is resolved.
+        classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.3"
+        classpath "com.github.dcendents:android-maven-gradle-plugin:2.1"
     }
 }
 


### PR DESCRIPTION
I've uploaded LongPressListener to bintray repository by following the [blog instructions](https://medium.com/scalereal/automate-publishing-android-library-to-bintray-using-github-actions-9b8ad8ab2698). I'll link them to jcenter after I finish working on project documentation. 
Check https://github.com/bintray/gradle-bintray-plugin for more information!